### PR TITLE
timeseries: fix config handling

### DIFF
--- a/qgeologis/timeseries_view.py
+++ b/qgeologis/timeseries_view.py
@@ -328,9 +328,9 @@ class TimeSeriesView(QWidget):
         win = plot_item.data_window()
         min_x, min_y, max_x, max_y = win.left(), win.top(), win.right(), win.bottom()
 
-        if config and 'min' in config.get_dict() and config['min'] is not None:
+        if config and config.get("min") is not None:
             min_y = float(config['min'])
-        if config and 'max' in config.get_dict() and config['max'] is not None:
+        if config and config.get("max") is not None:
             max_y = float(config['max'])
 
         # legend


### PR DESCRIPTION
Since ea988cd7d59bfea08e6320f2189a8b32b1ac43f5, config handling has been modified. However the config use has not been updated in `timeseries_view.py`. This PR fixes this point.

It is the same fix than the one which was implemented for `log_view.py` in 631acef9c02c0663b5c5f098fe6ec731e1e3eaa8.

Fixes #49 